### PR TITLE
Use random user data folder to prevent error 0x8007139F  "Expecting object to be local"

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -131,7 +131,7 @@ namespace WebDemoExe
 
 
                 AddBrowserArgument("--autoplay-policy=no-user-gesture-required");
-                Environment.SetEnvironmentVariable("WEBVIEW2_USER_DATA_FOLDER", Path.GetTempPath());
+                Environment.SetEnvironmentVariable("WEBVIEW2_USER_DATA_FOLDER", Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
 
                 if (dlg.DialogResult == true)
                 {
@@ -147,6 +147,7 @@ namespace WebDemoExe
 
             DataContext = this;
             InitializeComponent();
+            this.Closing += Window_Closing;
             AttachControlEventHandlers(webView);
 
             if ((bool)dlg.Fullscreen.IsChecked)
@@ -493,6 +494,11 @@ namespace WebDemoExe
         }
         // </BrowserProcessExited>
 
+        void Window_Closing(object sender, CancelEventArgs e)
+        {
+            closeExe(false);
+        }
+
         void WebView_HandleIFrames(object sender, CoreWebView2FrameCreatedEventArgs args)
         {
             _webViewFrames.Add(args.Frame);
@@ -607,13 +613,36 @@ namespace WebDemoExe
         }
         // </OnPermissionRequested>
 
-
-        void closeExe()
+        void closeExe(bool closeWindow = true)
         {
-            webView.Source = new Uri("about:blank");
-            webView.Dispose();
-            Close();
-            System.Environment.Exit(1);
+            try
+            {
+                if (webView != null)
+                {
+                    webView.Source = new Uri("about:blank");
+                    
+                    var webViewProcess = Process.GetProcessById(Convert.ToInt32(webView.CoreWebView2.BrowserProcessId));
+                    var webViewUserDataFolder = webView.CoreWebView2.Environment.UserDataFolder;
+
+                    webView.Dispose();
+                    webViewProcess.Kill();
+                    if (webViewProcess.WaitForExit(5000))
+                    {
+                        Directory.Delete(webViewUserDataFolder, true);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                MessageBox.Show($"Application close raised an exception = {e.Message}");
+            }
+
+            Closing -= Window_Closing;
+            if (closeWindow)
+            {
+                Close();
+                System.Environment.Exit(1);
+            }
         }
     }
 }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -641,7 +641,7 @@ namespace WebDemoExe
             if (closeWindow)
             {
                 Close();
-                System.Environment.Exit(1);
+                System.Environment.Exit(0);
             }
         }
     }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -615,33 +615,104 @@ namespace WebDemoExe
 
         void closeExe(bool closeWindow = true)
         {
+            string userDataFolder = null;
+            Process webViewProcess = null;
+            
             try
             {
+                if (webView?.CoreWebView2 != null)
+                {
+                    try
+                    {
+                        userDataFolder = webView.CoreWebView2.Environment?.UserDataFolder;
+                        
+                        var processId = webView.CoreWebView2.BrowserProcessId;
+                        if (processId > 0)
+                        {
+                            webViewProcess = Process.GetProcessById(Convert.ToInt32(processId));
+                        }
+                        
+                        webView.Source = new Uri("about:blank");
+                    }
+                    catch (Exception ex)
+                    {
+                        Trace.TraceError($"Error preparing WebView cleanup: {ex.Message}");
+                    }
+                }
+
                 if (webView != null)
                 {
-                    webView.Source = new Uri("about:blank");
-                    
-                    var webViewProcess = Process.GetProcessById(Convert.ToInt32(webView.CoreWebView2.BrowserProcessId));
-                    var webViewUserDataFolder = webView.CoreWebView2.Environment.UserDataFolder;
-
-                    webView.Dispose();
-                    webViewProcess.Kill();
-                    if (webViewProcess.WaitForExit(5000))
+                    try
                     {
-                        Directory.Delete(webViewUserDataFolder, true);
+                        webView.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        Trace.TraceError($"Error disposing WebView: {ex.Message}");
+                    }
+                    webView = null;
+                }
+
+                if (webViewProcess != null && !webViewProcess.HasExited)
+                {
+                    try
+                    {
+                        webViewProcess.CloseMainWindow();
+                        if (!webViewProcess.WaitForExit(3000))
+                        {
+                            webViewProcess.Kill();
+                            webViewProcess.WaitForExit(2000);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Trace.TraceError($"Error terminating WebView process: {ex.Message}");
+                    }
+                    finally
+                    {
+                        webViewProcess?.Dispose();
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(userDataFolder) && Directory.Exists(userDataFolder))
+                {
+                    try
+                    {
+                        var tempPath = Path.GetTempPath();
+                        if (userDataFolder.StartsWith(tempPath, StringComparison.OrdinalIgnoreCase))
+                        {
+                            Directory.Delete(userDataFolder, true);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Trace.TraceWarning($"Error cleaning user data folder: {ex.Message}");
                     }
                 }
             }
             catch (Exception e)
             {
-                MessageBox.Show($"Application close raised an exception = {e.Message}");
+                Trace.TraceError($"Critical error during application close: {e.Message}");
+                if (closeWindow)
+                {
+                    MessageBox.Show($"Application encountered an error during shutdown: {e.Message}", 
+                                   "Shutdown Error", MessageBoxButton.OK, MessageBoxImage.Warning);
+                }
             }
 
-            Closing -= Window_Closing;
-            if (closeWindow)
+            try
             {
-                Close();
-                System.Environment.Exit(0);
+                Closing -= Window_Closing;
+                if (closeWindow)
+                {
+                    Close();
+                    System.Environment.Exit(0);
+                }
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceError($"Error during final window close: {ex.Message}");
+                System.Environment.Exit(1);
             }
         }
     }


### PR DESCRIPTION
If there are unrelated Windows programs that utilize WebView2, starting of demo may result in `System.Runtime.InteropServices.COMException (0x8007139F): Expecting object to be local` error since WebDemo.exe tries to use pre-existing WebView2 process. This Pull Request places WebView2 user data folder under a random temp folder preventing the issue from occurring.

WebView2 process describes shared user data folder behavior: https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/process-model?tabs=csharp

![image](https://github.com/user-attachments/assets/55761255-0542-4146-89a1-5a090acb5d7b)

