### PR TITLE
Add propagatekeys config option so that application could handle Escape

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -49,7 +49,8 @@ namespace WebDemoExe
             var dlg = new DemoDialog();
 
 
-            var reader = new XmlTextReader("webdemoexe.xml");
+            var configFile = "webdemoexe.xml";
+            var reader = new XmlTextReader(configFile);
             reader.WhitespaceHandling = WhitespaceHandling.None;
 
             var currentTag = "";
@@ -86,6 +87,7 @@ namespace WebDemoExe
             {
                 dialogTitle = "xml error";
 
+                MessageBox.Show($"Could not parse {configFile}: {dialogTitle}: {e.Message}");
             }
 
             

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -64,7 +64,6 @@ namespace WebDemoExe
                     switch (reader.NodeType)
                     {
                         case XmlNodeType.Element:
-                            Trace.Write("ele", reader.Name);
                             currentTag = reader.Name;
                             
                             if (reader.IsEmptyElement)

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -42,6 +42,7 @@ namespace WebDemoExe
         IDictionary<(string, CoreWebView2PermissionKind, bool), bool> _cachedPermissions =
             new Dictionary<(string, CoreWebView2PermissionKind, bool), bool>();
 
+        bool _propagateKeys = false;
 
         public MainWindow()
         {
@@ -65,13 +66,19 @@ namespace WebDemoExe
                         case XmlNodeType.Element:
                             Trace.Write("ele", reader.Name);
                             currentTag = reader.Name;
+                            
+                            if (reader.IsEmptyElement)
+                            {
+                                if (currentTag.Equals("autostart")) autostart = true;
+                                if (currentTag.Equals("propagatekeys")) _propagateKeys = true;
+                            }
                             break;
 
                         case XmlNodeType.Text:
                             if (currentTag.Equals("title")) dialogTitle = reader.Value;
-                            if (currentTag.Equals("autostart")) autostart = true;
+                            if (currentTag.Equals("autostart")) autostart = XmlConvert.ToBoolean(reader.Value);
+                            if (currentTag.Equals("propagatekeys")) _propagateKeys = XmlConvert.ToBoolean(reader.Value);
                             break;
-
                     }
                 }
 
@@ -267,7 +274,7 @@ namespace WebDemoExe
 
         void WebView_KeyDown(object sender, KeyEventArgs e)
         {
-            if (e.IsRepeat) return;
+            if (e.IsRepeat || _propagateKeys) return;
 
             if (e.KeyboardDevice.IsKeyDown(Key.Escape))
             {

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ wrap your web demo into a windows exe format, just like a native demo.
 - exe is not signed, still have to click "run anyway", like with most demos
 - webdemoexe uses [webview2](https://learn.microsoft.com/en-us/microsoft-edge/webview2/) and creates a virtual host from the demo subfolder to run your demo
 - escape to close is handled by webdemoexe
+  - if you need to handle escape key manually, add `<propagatekeys/>` in the config.
 - no gesture is needed to auto play audio, if you normally display a play button, make sure it only shows when audiocontext stats is not "running"...
 
 ### ideas


### PR DESCRIPTION
In some more exotic use cases, like making a game or more interactive demo, it would be nice to have Escape button so that the program can control its behavior.

Optional config element `<propagatekeys/>` now disables WebDemoExe side handling of keyboard input in the webview

## Potential backwards compatibility issue with autostart XML element

Prior this PR autostart was interpreted to be true if config says `<autostart>yes</autostart>` or `<autostart>false</autostart>` as it was primarily looking for existence of XML element, not its value. This behavior is now changed to be a bit more aligned with XML.