### PR TITLE
New default domain, small cleanup, improve build-time validation

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -23,6 +23,8 @@ namespace WebDemoExe
     /// </summary>
     public partial class MainWindow : Window
     {
+        private string _appDomain = "webdemoexe.localhost";
+        
         CoreWebView2Environment _webViewEnvironment;
         CoreWebView2Environment WebViewEnvironment
         {
@@ -76,6 +78,7 @@ namespace WebDemoExe
 
                         case XmlNodeType.Text:
                             if (currentTag.Equals("title")) dialogTitle = reader.Value;
+                            if (currentTag.Equals("domain")) _appDomain = reader.Value;
                             if (currentTag.Equals("autostart")) autostart = XmlConvert.ToBoolean(reader.Value);
                             if (currentTag.Equals("propagatekeys")) _propagateKeys = XmlConvert.ToBoolean(reader.Value);
                             break;
@@ -220,9 +223,7 @@ namespace WebDemoExe
 
             bool IsAppContentUri(Uri source)
             {
-                // Sample virtual host name for the app's content.
-                // See CoreWebView2.SetVirtualHostNameToFolderMapping: https://learn.microsoft.com/dotnet/api/microsoft.web.webview2.core.corewebview2.setvirtualhostnametofoldermapping
-                return source.Host == "appassets.example";
+                return source.Host == _appDomain;
             }
 
             if (e.ProcessFailedKind == CoreWebView2ProcessFailedKind.FrameRenderProcessExited)
@@ -362,7 +363,7 @@ namespace WebDemoExe
 
         private string GetStartPageUri(CoreWebView2 webView2)
         {
-            string uri = "https://appassets.example/index.html";
+            string uri = $"https://{_appDomain}/index.html";
             if (webView2 == null)
             {
                 return uri;
@@ -381,7 +382,7 @@ namespace WebDemoExe
             if (e.IsSuccess)
             {
                 // Setup host resource mapping for local files
-                webView.CoreWebView2.SetVirtualHostNameToFolderMapping("appassets.example", "demo", CoreWebView2HostResourceAccessKind.DenyCors);
+                webView.CoreWebView2.SetVirtualHostNameToFolderMapping(_appDomain, "demo", CoreWebView2HostResourceAccessKind.DenyCors);
                 // Set StartPage Uri
                 webView.Source = new Uri(GetStartPageUri(webView.CoreWebView2));
 

--- a/WebDemoExe.csproj
+++ b/WebDemoExe.csproj
@@ -9,6 +9,12 @@
     <NoWin32Manifest>true</NoWin32Manifest>
     <Configurations>Debug;Release</Configurations>
     <ApplicationIcon>icon.ico</ApplicationIcon>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningLevel>5</WarningLevel>
+    <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)'=='x64'">
     <PlatformTarget>x64</PlatformTarget>
@@ -20,6 +26,9 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1724-prerelease" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3351.48" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" PrivateAssets="all" />
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/WebDemoExe.csproj
+++ b/WebDemoExe.csproj
@@ -20,63 +20,6 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="icon_.ico" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1724-prerelease" />
-	<PackageReference Include="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="assets\" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="assets\assets\lib_hdr_studiosmall.rgbe.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="assets\assets\mitch-harris-cPZ21gvclO8-unsplash__1_.jpg">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="assets\assets\Virgill-LJ-Box1.mp3">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="assets\cables.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="assets\credits.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="assets\doc.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="assets\index.html">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="assets\js\anaglyph_3d1_backup.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="assets\js\anaglyph_3d1_backup_nopath.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="assets\js\anaglyph_3d2_backup.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="assets\js\anaglyph_3d2_backup_nopath.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="assets\js\patch.js">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="assets\legal.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="assets\LICENCE">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="assets\readme.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="assets\scene.org.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 </Project>

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 ## webDemoExe
 
+[![Build](https://github.com/pandrr/WebDemoExe/actions/workflows/build.yml/badge.svg)](https://github.com/pandrr/WebDemoExe/actions/workflows/build.yml)
+
 wrap your web demo into a windows exe format, just like a native demo.
 
 [download](https://github.com/pandrr/WebDemoExe/releases)

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@ wrap your web demo into a windows exe format, just like a native demo.
 - edit webdemoexe.xml and change the title
 - rename webdemoexe.exe to your demo name
 - add `<autostart/>` into the config to not show the dialog at all and start directly, don't do this if you want to play audio without having another user interaction!
+- add `<domain>yourdomain.localhost</domain>` to customize the virtual host domain (defaults to webdemoexe.localhost)
 
 - if the url contains "webdemoexe_exit" it will exit, e.g. use window.location.hash="webdemoexe_exit"
 


### PR DESCRIPTION
- Use `webdemoexe.localhost` instead of `appassets.example`
- Cleanup projectfile
- Add build badge to readme
- Improve build-time validation and error reporting