### PR TITLE
Add config option to allow running insecure content

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -46,6 +46,28 @@ namespace WebDemoExe
 
         bool _propagateKeys = false;
 
+        HashSet<string> _additionalBrowserArguments = new HashSet<string>(StringComparer.Ordinal);
+
+        private void AddBrowserArgument(string argument)
+        {
+            if (string.IsNullOrWhiteSpace(argument))
+            {
+                return;
+            }
+
+            _additionalBrowserArguments.Add(argument.Trim());
+        }
+
+        private void SetAdditionalBrowserArguments()
+        {
+            if (_additionalBrowserArguments.Count == 0)
+            {
+                return;
+            }
+
+            Environment.SetEnvironmentVariable("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", string.Join(" ", _additionalBrowserArguments));
+        }
+
         public MainWindow()
         {
             var dlg = new DemoDialog();
@@ -58,6 +80,7 @@ namespace WebDemoExe
             var currentTag = "";
             var dialogTitle = "webDemoExe";
             var autostart = false;
+            var allowRunningInsecureContent = false;
 
             try
             {
@@ -73,6 +96,7 @@ namespace WebDemoExe
                             {
                                 if (currentTag.Equals("autostart")) autostart = true;
                                 if (currentTag.Equals("propagatekeys")) _propagateKeys = true;
+                                if (currentTag.Equals("allowrunninginsecurecontent")) allowRunningInsecureContent = true;
                             }
                             break;
 
@@ -81,6 +105,7 @@ namespace WebDemoExe
                             if (currentTag.Equals("domain")) _appDomain = reader.Value;
                             if (currentTag.Equals("autostart")) autostart = XmlConvert.ToBoolean(reader.Value);
                             if (currentTag.Equals("propagatekeys")) _propagateKeys = XmlConvert.ToBoolean(reader.Value);
+                            if (currentTag.Equals("allowrunninginsecurecontent")) allowRunningInsecureContent = XmlConvert.ToBoolean(reader.Value);
                             break;
                     }
                 }
@@ -91,9 +116,12 @@ namespace WebDemoExe
                 dialogTitle = "xml error";
 
                 MessageBox.Show($"Could not parse {configFile}: {dialogTitle}: {e.Message}");
-            }
+            }            
 
-            
+            if (allowRunningInsecureContent)
+            {
+                AddBrowserArgument("--allow-running-insecure-content");
+            }
 
             if (autostart==false)
             {
@@ -102,7 +130,7 @@ namespace WebDemoExe
                 dlg.ShowDialog();
 
 
-                Environment.SetEnvironmentVariable("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", "--autoplay-policy=no-user-gesture-required");
+                AddBrowserArgument("--autoplay-policy=no-user-gesture-required");
                 Environment.SetEnvironmentVariable("WEBVIEW2_USER_DATA_FOLDER", Path.GetTempPath());
 
                 if (dlg.DialogResult == true)
@@ -114,6 +142,8 @@ namespace WebDemoExe
                     return;
                 }
             }
+
+            SetAdditionalBrowserArguments();
 
             DataContext = this;
             InitializeComponent();

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@ wrap your web demo into a windows exe format, just like a native demo.
 - rename webdemoexe.exe to your demo name
 - add `<autostart/>` into the config to not show the dialog at all and start directly, don't do this if you want to play audio without having another user interaction!
 - add `<domain>yourdomain.localhost</domain>` to customize the virtual host domain (defaults to webdemoexe.localhost)
+- add `<allowrunninginsecurecontent/>` to allow insecure content (for example `ws://` for unencrypted websocket connections)
 
 - if the url contains "webdemoexe_exit" it will exit, e.g. use window.location.hash="webdemoexe_exit"
 
@@ -30,6 +31,7 @@ wrap your web demo into a windows exe format, just like a native demo.
 - webdemoexe uses [webview2](https://learn.microsoft.com/en-us/microsoft-edge/webview2/) and creates a virtual host from the demo subfolder to run your demo
 - escape to close is handled by webdemoexe
   - if you need to handle escape key manually, add `<propagatekeys/>` in the config.
+- if insecure connections are needed, set `<allowrunninginsecurecontent/>` (equivalent to [WebView flag](https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/webview-features-flags?tabs=dotnetcsharp) `allow-running-insecure-content`)
 - no gesture is needed to auto play audio, if you normally display a play button, make sure it only shows when audiocontext stats is not "running"...
 
 ### ideas


### PR DESCRIPTION
Add configuration option `<allowrunninginsecurecontent/>` to allow running insecure content.

URL: https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/webview-features-flags?tabs=dotnetcsharp
allow-running-insecure-content: Enables insecure content in Cast Web Runtime. This flag unblocks MSPs that serve content from HTTP sources.

This is for use cases where local WebDemoExe tries to access unsecured connections, for example, [light server protocol at Instanssi demoparty](https://github.com/turol/valoserveri)